### PR TITLE
Register default `CodePagesEncodingProvider`

### DIFF
--- a/SDRSharp.Plugin.Tetra1.2.csproj
+++ b/SDRSharp.Plugin.Tetra1.2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <Platforms>AnyCPU</Platforms>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -16,17 +16,12 @@
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile></DocumentationFile>
     <OutputPath>..\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Update="DialogConfigure.cs" />
@@ -44,22 +39,16 @@
 
   <ItemGroup>
     <Reference Include="SDRSharp.Common">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\SDRSharp.Common.dll</HintPath>
     </Reference>
     <Reference Include="SDRSharp.PanView">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\SDRSharp.PanView.dll</HintPath>
     </Reference>
     <Reference Include="SDRSharp.Radio">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\SDRSharp.Radio.dll</HintPath>
-    </Reference>
-    <Reference Include="Telerik.WinControls">
-      <HintPath>..\lib\Telerik.WinControls.dll</HintPath>
-    </Reference>
-    <Reference Include="Telerik.WinControls.UI">
-      <HintPath>..\lib\Telerik.WinControls.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="TelerikCommon">
-      <HintPath>..\lib\TelerikCommon.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/TetraPanel.cs
+++ b/TetraPanel.cs
@@ -11,7 +11,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Windows.Forms;
 using Microsoft.VisualBasic;
-using Telerik.WinControls.UI;
 
 namespace SDRSharp.Tetra
 {

--- a/TetraPlugin.cs
+++ b/TetraPlugin.cs
@@ -21,6 +21,7 @@ namespace SDRSharp.Tetra
 
         public void Initialize(ISharpControl control)
         {
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
             _controlInterface = control;
             _qpskPanel = new TetraPanel(_controlInterface);
         }


### PR DESCRIPTION
The plugin is crashing when calling `SdsParser.ParseTextMessage()` because of a missing `CodePagesEncodingProvider` registration:
`No data is available for encoding 850. For information on defining a custom encoding, see the documentation for the Encoding.RegisterProvider method.`
I've added this to the plugin `Initialize()` method.
While in the process I also updated to .Net 7 as required by the current SDR# Plugin SDK.
Tested with the current release 1919 (2023-07-28) and now works as expected.